### PR TITLE
Simpler faster (illustration, for fun)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,11 +68,6 @@ THE POSSIBILITY OF SUCH DAMAGE.
         <jmh.version>1.27</jmh.version>
 
         <!--
-            Java source/target to use for compilation.
-          -->
-        <javac.target>18</javac.target>
-
-        <!--
             Name of the benchmark Uber-JAR to generate.
           -->
         <uberjar.name>benchmarks</uberjar.name>
@@ -85,13 +80,12 @@ THE POSSIBILITY OF SUCH DAMAGE.
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.0</version>
                 <configuration>
-                    <compilerVersion>${javac.target}</compilerVersion>
-                    <source>18</source>
-                    <target>18</target>
+			 <source>21</source>
+			<target>21</target>
                     <compilerArgs>
-                        <compilerArg>--enable-preview</compilerArg>
-                        <compilerArg>--add-modules</compilerArg>
-                        <compilerArg>jdk.incubator.vector,jdk.incubator.foreign</compilerArg>
+			<compilerArg>--enable-preview</compilerArg>
+			<compilerArg>--add-modules</compilerArg>
+                        <compilerArg>java.base,jdk.incubator.vector</compilerArg>
                     </compilerArgs>
                 </configuration>
             </plugin>

--- a/src/main/java/com/augustnagro/utf8/OneBranchTooMany.java
+++ b/src/main/java/com/augustnagro/utf8/OneBranchTooMany.java
@@ -1,8 +1,6 @@
 package com.augustnagro.utf8;
 
-import jdk.incubator.foreign.MemoryAccess;
-import jdk.incubator.foreign.MemoryLayouts;
-import jdk.incubator.foreign.MemorySegment;
+import java.lang.foreign.MemorySegment;
 import jdk.incubator.vector.ByteVector;
 import jdk.incubator.vector.VectorSpecies;
 import org.openjdk.jmh.annotations.*;

--- a/src/main/java/com/augustnagro/utf8/OneBranchTooMany.java
+++ b/src/main/java/com/augustnagro/utf8/OneBranchTooMany.java
@@ -23,7 +23,8 @@ import static jdk.incubator.vector.VectorOperators.*;
     }
 )
 public class OneBranchTooMany {
-
+  // It is unclear what this benchmark is supposed to do.
+/*
   private static final long SEED = 4691838106802987135L;
   private static final VectorSpecies<Byte> SPECIES = ByteVector.SPECIES_128;
   private static final ByteOrder BYTE_ORDER = ByteOrder.nativeOrder();
@@ -114,5 +115,5 @@ public class OneBranchTooMany {
 
     return isAllPositive && res.test(IS_DEFAULT).allTrue();
   }
-
+*/
 }


### PR DESCRIPTION
This replaces a 25-minute benchmark with a 19 seconds one, and it drastically improves the performance in some cases. I have not updated the README, and I image you won't want to merge the PR as is, but the performance boost is significant for some cases.

On an Ice Lake server (with 512-bit registers)....

This PR:

```
Benchmark               (testFile)   Mode  Cnt      Score   Error  Units
BenchJDK.jdk         /twitter.json  thrpt         952.397          ops/s
BenchJDK.scalar      /twitter.json  thrpt        2234.691          ops/s
BenchJDK.vector_128  /twitter.json  thrpt       14630.812          ops/s
BenchJDK.vector_256  /twitter.json  thrpt       17697.810          ops/s
BenchJDK.vector_512  /twitter.json  thrpt       31678.039          ops/s
```

In GB/s, it is...

```
jdk                  0.6 GB/s
scalar             1.4 GB/s
vector_128     9 GB/s
vector_256     11 GB/s
vector_512     20 GB/s
```

These are reasonable results !!!

Previous results (same machine): 

```
Benchmark                          (branchPrediction)              (testFile)   Mode  Cnt       Score        Error  Units
BenchJDK.jdk                                      N/A           /twitter.json  thrpt    5    1730.981 ±     10.969  ops/s
BenchJDK.vector_128                               N/A           /twitter.json  thrpt    5    5312.508 ±     59.222  ops/s
BenchJDK.vector_256                               N/A           /twitter.json  thrpt    5    8186.286 ±     47.844  ops/s
BenchJDK.vector_512                               N/A           /twitter.json  thrpt    5   31273.521 ±    227.835  ops/s
```

So, in my tests, I triple the performance for `vector_128` and double it for `vector_256`.

An interesting addition in this PR is a scalar validation function, which allows you to see directly the benefits of the SIMD operations.

This PR also retains just one benchmark file, because, again, I want quick benchmarks as I do not like to wait several minutes for the results. Ultimately, one would want the input file to be a parameter but I could not get it to work using the instructions in the README (the files are seemingly never found). 

The important point here is that the performance can be made better.